### PR TITLE
патч для namespace'ов

### DIFF
--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -175,6 +175,12 @@ TSRMLS_DC)
 	/* We never promised the calling scope we'd leave classname untouched :) */
 	php_strtolower(classname, classname_len);
 
+	/* Ignore leading "\" */
+	if (classname[0] == '\\') {
+		classname = &classname[1];
+		classname_len--;
+	}
+
 #ifdef ZEND_ENGINE_2
 	if (zend_hash_find(EG(class_table), classname, classname_len + 1, (void**)&ze) == FAILURE ||
 		!ze || !*ze) {


### PR DESCRIPTION
Сделал небольшой патч по просьбе наших тестеров.
Фиксит такой пример:
<?php

namespace Test;
class Foo {
    public function bar() {
        echo "Called original bar()\n";
    }
}

\runkit_method_redefine('\Test\Foo', 'bar', '', 'echo "Mocked";');

$foo = new \Test\Foo();
$foo->bar();
