### PR TITLE
Fix typo in README

### DIFF
--- a/README
+++ b/README
@@ -120,6 +120,6 @@ configure --enable-runkit
 
 After all run
 
-nmake
+make
 
 Now you should have the "php_runkit.dll" file.


### PR DESCRIPTION
This should be make not actually nmake, right?
