### PR TITLE
fix bug with inherited old-style constructors

### DIFF
--- a/php_runkit.h
+++ b/php_runkit.h
@@ -335,9 +335,10 @@ struct _php_runkit_sandbox_object {
 }
 
 #ifdef ZEND_ENGINE_2
-#define PHP_RUNKIT_ADD_MAGIC_METHOD(ce, method, fe) { \
-	if ((strcmp((method), (ce)->name) == 0) || \
-		(strcmp((method), "__construct") == 0)) {	(ce)->constructor	= (fe); (fe)->common.fn_flags = ZEND_ACC_CTOR; } \
+#define PHP_RUNKIT_ADD_MAGIC_METHOD(ce, method, fe, orig_fe) { \
+	if ((strcasecmp((method), (ce)->name) == 0) || \
+		(strcmp((method), "__construct") == 0)) {	(ce)->constructor = (fe); (fe)->common.fn_flags = ZEND_ACC_CTOR; } \
+	else if ((ce)->constructor && (ce)->constructor == orig_fe) {	(ce)->constructor = (fe); (fe)->common.fn_flags = ZEND_ACC_CTOR; } \
 	else if (strcmp((method), "__destruct") == 0) {	(ce)->destructor	= (fe); (fe)->common.fn_flags = ZEND_ACC_DTOR; } \
 	else if (strcmp((method), "__clone") == 0)  {	(ce)->clone			= (fe); (fe)->common.fn_flags = ZEND_ACC_CLONE; } \
 	else if (strcmp((method), "__get") == 0)		(ce)->__get			= (fe); \
@@ -355,7 +356,7 @@ struct _php_runkit_sandbox_object {
 #define PHP_RUNKIT_DESTROY_FUNCTION(fe) 	destroy_zend_function(fe TSRMLS_CC);
 #else
 #define PHP_RUNKIT_DESTROY_FUNCTION(fe) 	destroy_zend_function(fe);
-#define PHP_RUNKIT_ADD_MAGIC_METHOD(ce, method, fe)
+#define PHP_RUNKIT_ADD_MAGIC_METHOD(ce, method, fe, orig_fe)
 #define PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe)
 #endif /* ZEND_ENGINE_2 */
 #endif /* PHP_RUNKIT_MANIPULATION */

--- a/runkit_classes.c
+++ b/runkit_classes.c
@@ -95,7 +95,7 @@ static int php_runkit_inherit_methods(zend_function *fe, zend_class_entry *ce TS
 	}
 	efree(lower_function_name);
 
-	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, fe->common.function_name, fe);
+	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, fe->common.function_name, fe, NULL);
 
 	return ZEND_HASH_APPLY_KEEP;
 }

--- a/tests/runkit_add_old_style_ctor.phpt
+++ b/tests/runkit_add_old_style_ctor.phpt
@@ -1,0 +1,19 @@
+--TEST--
+add old-style parent ctor
+--FILE--
+<?php
+
+class Test {
+}
+
+class FOO_test extends test {
+}
+
+runkit_method_add("test", "test", "", "var_dump('new constructor');");
+$a = new foo_test;
+
+echo "==DONE==\n";
+?>
+--EXPECT--
+string(15) "new constructor"
+==DONE==

--- a/tests/runkit_add_old_style_ctor1.phpt
+++ b/tests/runkit_add_old_style_ctor1.phpt
@@ -1,0 +1,22 @@
+--TEST--
+add old-style parent ctor (existing ctor)
+--FILE--
+<?php
+
+class Test {
+}
+
+class FOO_test extends test {
+	function foo_test() {
+		var_dump("foo_test ctor");
+	}
+}
+
+runkit_method_add("test", "test", "", "var_dump('new constructor');");
+$a = new foo_test;
+
+echo "==DONE==\n";
+?>
+--EXPECT--
+string(13) "foo_test ctor"
+==DONE==

--- a/tests/runkit_redefine_old_style_ctor.phpt
+++ b/tests/runkit_redefine_old_style_ctor.phpt
@@ -1,0 +1,22 @@
+--TEST--
+redefine old-style parent ctor 
+--FILE--
+<?php
+
+class Test {
+	function test() {
+		var_dump("original constructor");
+	}
+}
+
+class FOO_test extends test {
+}
+
+runkit_method_redefine("test", "test", "", "var_dump('new constructor');");
+$a = new foo_test;
+
+echo "==DONE==\n";
+?>
+--EXPECT--
+string(15) "new constructor"
+==DONE==


### PR DESCRIPTION
we need some additional safechecks when redefining/adding these cursed
old-style ctors.
