### PR TITLE
runkit_method_redefine() must update prototypes

### DIFF
--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -298,6 +298,10 @@ int php_runkit_update_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce
 		scope = php_runkit_locate_scope(ce, cfe, fname, fname_len);
 		if (scope != ancestor_class) {
 			/* This method was defined below our current level, leave it be */
+#ifdef ZEND_ENGINE_2
+			cfe->common.prototype = _php_runkit_get_method_prototype(scope->parent, fname, fname_len TSRMLS_CC);
+			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), (apply_func_args_t)php_runkit_update_children_methods, 7, ancestor_class, ce, fe, fname, fname_len, orig_fe, add_or_update);
+#endif
 			efree(fname_lower);
 			return ZEND_HASH_APPLY_KEEP;
 		}

--- a/tests/runkit_method_redefine_update_proto.phpt
+++ b/tests/runkit_method_redefine_update_proto.phpt
@@ -1,0 +1,40 @@
+--TEST--
+runkit_method_redefine() must also update children methods' prototypes 
+--FILE--
+<?php
+class a
+{
+        protected function foo()
+        {
+        }
+
+        public function test()
+        {
+                $this->foo();
+        }
+}
+
+class b extends a {
+
+        protected function foo()
+        {
+        }
+}
+
+class c extends b {
+        function bar()
+        {
+                $this->test();
+        }
+}
+
+runkit_method_redefine('a', 'foo', '', 'var_dump("new foo()");');
+
+$c = new c;
+$c->bar();
+
+echo "==DONE==\n";
+
+?>
+--EXPECT--
+==DONE==


### PR DESCRIPTION
.. of children methods when redefining their parent methods
