### PR TITLE
Fixing 'uninitialized variable' compiler error

### DIFF
--- a/runkit_sandbox.c
+++ b/runkit_sandbox.c
@@ -1612,7 +1612,7 @@ PHP_FUNCTION(runkit_sandbox_output_handler)
 	zval *sandbox;
 	zval *callback = NULL;
 	php_runkit_sandbox_object *objval;
-	char *name;
+	char *name = NULL;
 	int callback_is_true = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O|z", &sandbox, php_runkit_sandbox_class_entry, &callback) == FAILURE) {


### PR DESCRIPTION
Tried compiling against a snapshot of PHP 5.6 and got the following:

```
/Users/nate/Projects/runkit/runkit_sandbox.c:1639:6: error: variable 'name' is used uninitialized whenever '&&' condition is false [-Werror,-Wsometimes-uninitialized]
        if (callback && callback_is_true &&
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1647:6: note: uninitialized use occurs here
        if (name) {
            ^~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1639:6: note: remove the '&&' if its condition is always true
        if (callback && callback_is_true &&
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1639:6: error: variable 'name' is used uninitialized whenever '&&' condition is false [-Werror,-Wsometimes-uninitialized]
        if (callback && callback_is_true &&
            ^~~~~~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1647:6: note: uninitialized use occurs here
        if (name) {
            ^~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1639:6: note: remove the '&&' if its condition is always true
        if (callback && callback_is_true &&
            ^~~~~~~~~~~
/Users/nate/Projects/runkit/runkit_sandbox.c:1615:12: note: initialize the variable 'name' to silence this warning
        char *name;
                  ^
                   = NULL
2 errors generated.
make: *** [runkit_sandbox.lo] Error 1
```

This patch allows runkit to compile successfully.
