### PR TITLE
Fixed build failure against php-5.6.0alpha3

### DIFF
--- a/runkit_props.c
+++ b/runkit_props.c
@@ -568,28 +568,6 @@ static int php_runkit_def_prop_add(char *classname, int classname_len, char *pro
 }
 /* }}} */
 
-/* {{{ php_runkit_dump_string */
-static inline void php_runkit_dump_string(const char *str, int len) {
-	int j;
-	for (j=0; j<len; j++) {
-		printf("%c", str[j]);
-	}
-}
-/* }}} */
-
-/* {{{ php_runkit_dump_hashtable_keys */
-static inline void php_runkit_dump_hashtable_keys(HashTable* ht) {
-	HashPosition pos;
-	void *ptr;
-	for(zend_hash_internal_pointer_end_ex(ht, &pos);
-	    zend_hash_get_current_data_ex(ht, (void*)&ptr, &pos) == SUCCESS;
-	    zend_hash_move_backwards_ex(ht, &pos)) {
-		printf("key = ");
-		php_runkit_dump_string(pos->arKey, pos->nKeyLength);
-	}
-}
-/* }}} */
-
 /* {{{ php_runkit_def_prop_remove_int */
 int php_runkit_def_prop_remove_int(zend_class_entry *ce, const char *propname, int propname_len, zend_class_entry *class_we_originally_removing_from,
                                    zend_bool was_static, zend_bool remove_from_objects,


### PR DESCRIPTION
Removed two unused functions.

```
...
/tmp/runkit/runkit_props.c:581:20: error: unused function 'php_runkit_dump_hashtable_keys' [-Werror,-Wunused-function]
static inline void php_runkit_dump_hashtable_keys(HashTable* ht) {
                   ^
1 error generated.
make: *** [runkit_props.lo] Error 1
$ php -v
PHP 5.6.0alpha3 (cli) (built: Mar 17 2014 23:15:45)
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.6.0-dev, Copyright (c) 1998-2014 Zend Technologies
```
