### PR TITLE
Fix runkit function manipulation for namespaced functions with a leading "\" (Issue #90)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,9 @@ Execute code in restricted environment (sandboxing).
     <api>stable</api>
    </stability>
    <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
-   <notes>...
+   <notes>
+	   Fixes:
+	       * Leading backslashes are now allowed in function manipulation functions (Thanks to Tyson Andre)
    </notes>
 
  <contents>
@@ -188,6 +190,7 @@ Execute code in restricted environment (sandboxing).
     <file name="bug4519.inc" role="test" />
     <file name="bug4519.phpt" role="test" />
     <file name="namespaces.phpt" role="test" />
+    <file name="namespaces_functions.phpt" role="test" />
     <file name="runkit_default_property_add.phpt" role="test" />
     <file name="runkit_default_property_add_and_remove_for_class_with_dynamic_properties.phpt" role="test" />
     <file name="runkit_default_property_add_to_subclasses.phpt" role="test" />

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -264,7 +264,7 @@ int php_runkit_fetch_interface(const char *classname, int classname_len, zend_cl
 
 /* Ignore leading "\" for namespaced functions and classes. */
 #define PHP_RUNKIT_NORMALIZE_NAMESPACE(name) \
-	if (name[0] == '\\') { \
+	if (name##_len > 0 && name[0] == '\\') { \
 		name++; \
 		name##_len--; \
 	}

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -262,6 +262,13 @@ int php_runkit_fetch_interface(const char *classname, int classname_len, zend_cl
 #define PHP_RUNKIT_HASH_KEYLEN(hash_key)		((hash_key)->nKeyLength)
 #endif /* Version Agnosticism */
 
+/* Ignore leading "\" for namespaced functions and classes. */
+#define PHP_RUNKIT_NORMALIZE_NAMESPACE(name) \
+	if (name[0] == '\\') { \
+		name++; \
+		name##_len--; \
+	}
+
 #define PHP_RUNKIT_MAKE_LOWERCASE_COPY(name) \
 	name##_lower = estrndup(name, name##_len); \
 	name##_lower_len = name##_len; \

--- a/runkit_constants.c
+++ b/runkit_constants.c
@@ -33,10 +33,7 @@ static int php_runkit_fetch_const(char *cname, int cname_len, zend_constant **co
 #if RUNKIT_ABOVE53
 	char *separator;
 
-	if (cname_len > 0 && cname[0] == '\\') {
-		++cname;
-		--cname_len;
-	}
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(cname);
 
 	separator = (char *) zend_memrchr(cname, '\\', cname_len);
 	if (separator) {
@@ -182,10 +179,7 @@ static int php_runkit_constant_add(char *classname, int classname_len, char *con
 		zend_constant c;
 
 #if RUNKIT_ABOVE53
-		if (constname_len > 0 && constname[0] == '\\') {
-			++constname;
-			--constname_len;
-		}
+		PHP_RUNKIT_NORMALIZE_NAMESPACE(constname);
 #endif
 
 		/* Traditional global constant */

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -61,6 +61,7 @@ static int php_runkit_fetch_function(int fname_type, const char *fname, int fnam
 	zend_function *fe;
 	PHP_RUNKIT_DECL_STRING_PARAM(fname_lower)
 
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(fname);
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(fname);
 	if (fname_lower == NULL) {
 		PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR;
@@ -585,6 +586,7 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 	}
 
 	/* UTODO */
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(funcname);
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(funcname);
 	if (funcname_lower == NULL) {
 		PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR;
@@ -688,6 +690,7 @@ PHP_FUNCTION(runkit_function_remove)
 		RETURN_FALSE;
 	}
 
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(fname);
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(fname);
 	if (fname_lower == NULL) {
 		PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR;
@@ -722,6 +725,7 @@ PHP_FUNCTION(runkit_function_remove)
 	} \
 	\
 	/* UTODO */ \
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(dfunc) \
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(dfunc); \
 	if (dfunc_lower == NULL) { \
 		PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR; \
@@ -747,6 +751,7 @@ PHP_FUNCTION(runkit_function_rename)
 		RETURN_FALSE;
 	}
 
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(sfunc);
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(sfunc);
 	if (sfunc_lower == NULL) {
 		efree(dfunc_lower);
@@ -811,6 +816,7 @@ PHP_FUNCTION(runkit_function_copy)
 		RETURN_FALSE;
 	}
 
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(sfunc);
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(sfunc);
 	if (sfunc_lower == NULL) {
 		efree(dfunc_lower);

--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -52,11 +52,7 @@ int php_runkit_fetch_class_int(const char *classname, int classname_len, zend_cl
 	PHP_RUNKIT_DECL_STRING_PARAM(classname_lower)
 
 	/* Ignore leading "\" */
-	if (classname[0] == '\\') {
-		++classname;
-		--classname_len;
-	}
-
+	PHP_RUNKIT_NORMALIZE_NAMESPACE(classname);
 
 	PHP_RUNKIT_MAKE_LOWERCASE_COPY(classname);
 	if (classname_lower == NULL) {

--- a/tests/namespaces_functions.phpt
+++ b/tests/namespaces_functions.phpt
@@ -1,0 +1,47 @@
+--TEST--
+runkit_function_add(), runkit_function_redefine(), runkit_function_rename() & runkit_function_copy() functions with namespaces
+--SKIPIF--
+<?php
+	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
+?>
+--INI--
+error_reporting=E_ALL
+display_errors=on
+--FILE--
+<?php
+
+namespace Test;
+function bar() {
+	echo "Called original bar()\n";
+}
+
+runkit_function_redefine('Test\bar', '', 'echo "Mocked\n";');
+runkit_function_add('\Test\m', '', '');
+runkit_function_redefine('\Test\m', '', 'echo "New mocked\n";');
+runkit_function_add('Test\p', '', 'echo "New\n";');
+runkit_function_rename('Test\m', '\Test\n');
+runkit_function_rename('\Test\p', 'Test\s');
+runkit_function_copy('\Test\n', 'Test\o');
+runkit_function_copy('Test\s', '\Test\q');
+
+bar();
+o();
+q();
+\Test\bar();
+\Test\o();
+\Test\q();
+
+runkit_function_remove('Test\n');
+runkit_function_remove('\Test\s');
+n();
+?>
+--EXPECTF--
+Mocked
+New mocked
+New
+Mocked
+New mocked
+New
+
+Fatal error: Call to undefined function Test\n() in %s on line %d


### PR DESCRIPTION
And add a test of runkit function manipulation for namespaced functions (Based off of namespaces.phpt)

Runkit will allow both "\NamespaceName\ClassName" and "NamespaceName\ClassName" for runkit method manipulation functions.
It should also allow both "\NamespaceName\function_name" and "NamespaceName\function_name"

It was previously only working properly for function names of the form "NamespaceName\function_name".

I verified that all tests passed after this change, including the test that I added.
