### PR TITLE
fix test with system php-fpm

### DIFF
--- a/tests/_fpm_include.inc
+++ b/tests/_fpm_include.inc
@@ -46,7 +46,7 @@ function run_fpm($config, &$out = false, $extra_args = '') /* {{{ */
      * shell in php (why?!?) we need a little shell trickery, so that we can
      * actually kill php-fpm */
     //echo file_get_contents('../tmp-php.ini');
-    $fpm = proc_open('killit () { kill $child; }; trap killit TERM; '.get_fpm_path().' -O -y '.$cfg." ".$extra_args.' 2>&1 & child=$!; wait', $desc, $pipes);
+    $fpm = proc_open('killit () { kill $child; }; trap killit TERM; '.get_fpm_path().'-n -O -y '.$cfg." ".$extra_args.' 2>&1 & child=$!; wait', $desc, $pipes);
     register_shutdown_function('_fpm_shutdown_function', $fpm, $cfg);
     if ($out !== false) {
         $out = $pipes[1];
@@ -118,6 +118,7 @@ function fpm_test($code, $extra_args) {
 [global]
 error_log = $logfile
 daemonize = no
+log_level = warning
 [unconfined]
 listen = 127.0.0.1:$port
 pm = dynamic
@@ -132,7 +133,6 @@ EOT;
 	}
 	$fpm = run_fpm($cfg, $tail, $extra_args);
 	if (is_resource($fpm)) {
-		fpm_display_log($tail, 2);
 		foreach ($code as $code_str) {
 			file_put_contents($srcfile, $code_str);
 			try {
@@ -144,7 +144,6 @@ EOT;
 			}
 		}
 		proc_terminate($fpm);
-		echo stream_get_contents($tail);
 		fclose($tail);
 		proc_close($fpm);
 	}

--- a/tests/_fpm_include.inc
+++ b/tests/_fpm_include.inc
@@ -46,7 +46,7 @@ function run_fpm($config, &$out = false, $extra_args = '') /* {{{ */
      * shell in php (why?!?) we need a little shell trickery, so that we can
      * actually kill php-fpm */
     //echo file_get_contents('../tmp-php.ini');
-    $fpm = proc_open('killit () { kill $child; }; trap killit TERM; '.get_fpm_path().'-n -O -y '.$cfg." ".$extra_args.' 2>&1 & child=$!; wait', $desc, $pipes);
+    $fpm = proc_open('killit () { kill $child; }; trap killit TERM; '.get_fpm_path().' -n -O -y '.$cfg." ".$extra_args.' 2>&1 & child=$!; wait', $desc, $pipes);
     register_shutdown_function('_fpm_shutdown_function', $fpm, $cfg);
     if ($out !== false) {
         $out = $pipes[1];
@@ -118,7 +118,6 @@ function fpm_test($code, $extra_args) {
 [global]
 error_log = $logfile
 daemonize = no
-log_level = warning
 [unconfined]
 listen = 127.0.0.1:$port
 pm = dynamic
@@ -133,6 +132,7 @@ EOT;
 	}
 	$fpm = run_fpm($cfg, $tail, $extra_args);
 	if (is_resource($fpm)) {
+		fpm_display_log($tail, 2);
 		foreach ($code as $code_str) {
 			file_put_contents($srcfile, $code_str);
 			try {

--- a/tests/runkit_fpm_internal_function_restore.phpt
+++ b/tests/runkit_fpm_internal_function_restore.phpt
@@ -14,12 +14,10 @@ echo _chop('A B '), "\n";
 echo __chop('C D '), "\n";
 echo "Test End\n";
 EOT;
-fpm_test(array($code, $code, $code), "-d extension_dir=modules/ -d extension=runkit.so -d runkit.internal_override=1");
+fpm_test(array($code, $code, $code), "-d extension=modules/runkit.so -d runkit.internal_override=1");
 ?>
 Done
 --EXPECTF--
-[%s] NOTICE: fpm is running, pid %d
-[%s] NOTICE: ready to handle connections
 Test Start
 A B
 C D
@@ -38,8 +36,6 @@ C D
 Test End
 
 Request ok
-[%s] NOTICE: Terminating ...
-[%s] NOTICE: exiting, bye-bye!
 Done
 --CLEAN--
 <?php

--- a/tests/runkit_fpm_internal_function_restore.phpt
+++ b/tests/runkit_fpm_internal_function_restore.phpt
@@ -18,6 +18,8 @@ fpm_test(array($code, $code, $code), "-d extension=modules/runkit.so -d runkit.i
 ?>
 Done
 --EXPECTF--
+[%s] NOTICE: fpm is running, pid %d
+[%s] NOTICE: ready to handle connections
 Test Start
 A B
 C D


### PR DESCRIPTION
When using system php-fpm, test can fails, this should fix this:

- -n option to not use system php.ini (which can include additional extensions)
-  don't change extension_dir (is enough, previous not really required with this change)
- don't log notice, only warning (additional one break expected output, such as "NOTICE: systemd monitor interval set to 10000ms")
