### PR TITLE
Fix private property from parent class

### DIFF
--- a/runkit_props.c
+++ b/runkit_props.c
@@ -292,7 +292,7 @@ int php_runkit_def_prop_add_int(zend_class_entry *ce, const char *propname, int 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot find just added property's info");
 			return FAILURE;
 		}
-		if (visibility & ZEND_ACC_PRIVATE) {
+		if (visibility & (ZEND_ACC_PRIVATE | ZEND_ACC_SHADOW)) {
 			char *newkey;
 			int newkey_len;
 			char *oldkey;


### PR DESCRIPTION
I have problem in importing class with extend a class, where was private property.
Private property import in wrong order and property in imported class rewrite value in parent class properties.
This bug is in 1.0.4 release and i run test on php 5.4.20.
